### PR TITLE
Support for multiple `QA Approved` labels and sign off metadata

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": false,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "quoteProps": "preserve",
+  "printWidth": 120
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sign-off-action",
-  "version": "0.0.1",
+  "version": "1.3.0",
   "description": "Github Action that handles a Release Candidate or Hotfix sign off.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR add

- Add support for multiple "QA Approved" labels for each QA team ([sample issue](https://github.com/loopsocial/zeffo/issues/7790))
- Upload release asset `sign-off-metadata.json` which includes full issue object including labels ([sample release](https://github.com/loopsocial/zeffo/releases/tag/v20240916.1))
